### PR TITLE
Add low-VRAM LoRA workflow

### DIFF
--- a/GGUF_TRAINING.md
+++ b/GGUF_TRAINING.md
@@ -1,0 +1,38 @@
+# Low VRAM Llama3 Fine-tuning Guide
+
+This document outlines a minimal workflow for fine-tuning Llama 3 using LoRA with 4-bit quantization and exporting the result as a `.gguf` file.
+
+## 1. Prepare the Dataset
+
+Create a JSON Lines (`.jsonl`) file. Each line should contain a single JSON object with two fields:
+
+```json
+{"text": "<prompt and answer in Llama3 chat format>"}
+```
+
+The `text` field should already be formatted using the [Llama3 chat template](code/chat_template/llama-3-instruct.jinja). For example:
+
+```json
+{"text": "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nYou are a helpful assistant.<|eot_id|><|start_header_id|>user<|end_header_id|>\n\nWhat is the capital of France?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nThe capital of France is Paris.<|eot_id|>"}
+```
+
+## 2. Install Requirements
+
+```bash
+pip install -r requirements.txt
+pip install llama_cpp  # required for GGUF conversion
+```
+
+## 3. Run Training
+
+Use the provided script `train_lora_gguf.py`:
+
+```bash
+python code/train_lora_gguf.py --data /path/to/data.jsonl --epochs 3 --output /project/models/my-llama3
+```
+
+Training uses 4‑bit QLoRA to reduce VRAM requirements. Adjust `--epochs` as desired.
+
+## 4. Resulting Files
+
+After training completes you will find the Hugging Face model weights under the chosen output directory and a compressed `model.gguf` file ready for use with `llama.cpp`-compatible runtimes.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ If you do not NVIDIA AI Workbench installed, first complete the installation for
 6. On the top right of the window, select **Jupyterlab**. 
 
 7. Navigate to the `code` directory of the project. Then, open your fine-tuning notebook of choice and get started. Happy coding!
+8. Alternatively, see [GGUF_TRAINING.md](GGUF_TRAINING.md) for a lightweight LoRA workflow that exports to `.gguf`.
 
 ## Tutorial (CLI-Only)
 Some users may choose to use the **CLI tool only** instead of the Desktop App. If you do not NVIDIA AI Workbench installed, first complete the installation for AI Workbench [here](https://www.nvidia.com/en-us/deep-learning-ai/solutions/data-science/workbench/). Then, 
@@ -144,6 +145,7 @@ Some users may choose to use the **CLI tool only** instead of the Desktop App. I
    * Specify the Hugging Face Token as a project secret.
 
 6. Navigate to the `code` directory of the project. Then, open your fine-tuning notebook of choice and get started. Happy coding!
+7. Alternatively, see [GGUF_TRAINING.md](GGUF_TRAINING.md) for a lightweight LoRA workflow that exports to `.gguf`.
 
 # License
 This NVIDIA AI Workbench example project is under the [Apache 2.0 License](https://github.com/NVIDIA/workbench-example-llama3-finetune/blob/main/LICENSE.txt)

--- a/code/train_lora_gguf.py
+++ b/code/train_lora_gguf.py
@@ -1,0 +1,78 @@
+import argparse
+import os
+
+import torch
+from datasets import load_dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM, TrainingArguments
+from transformers import BitsAndBytesConfig
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+from trl import SFTTrainer
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Finetune Llama 3 with LoRA and export to GGUF")
+    parser.add_argument("--model", default="meta-llama/Meta-Llama-3-8B-Instruct", help="Base HF model id")
+    parser.add_argument("--data", required=True, help="Path to training data in JSONL format")
+    parser.add_argument("--output", default="./lora-gguf-model", help="Directory to save model")
+    parser.add_argument("--epochs", type=int, default=1)
+    return parser.parse_args()
+
+
+def load_data(path):
+    return load_dataset("json", data_files=path)["train"]
+
+
+def main():
+    args = parse_args()
+
+    dataset = load_data(args.data)
+
+    bnb_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_compute_dtype=torch.float16,
+        bnb_4bit_use_double_quant=True,
+        bnb_4bit_quant_type="nf4",
+    )
+
+    model = AutoModelForCausalLM.from_pretrained(args.model, quantization_config=bnb_config, device_map="auto")
+    model = prepare_model_for_kbit_training(model)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    tokenizer.pad_token = tokenizer.eos_token
+
+    lora_config = LoraConfig(r=16, lora_alpha=32, target_modules=["q_proj", "v_proj"], lora_dropout=0.05)
+    model = get_peft_model(model, lora_config)
+
+    training_args = TrainingArguments(
+        output_dir=args.output,
+        num_train_epochs=args.epochs,
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=4,
+        logging_steps=10,
+        save_steps=100,
+        bf16=True,
+    )
+
+    trainer = SFTTrainer(
+        model=model,
+        tokenizer=tokenizer,
+        train_dataset=dataset,
+        dataset_text_field="text",
+        args=training_args,
+    )
+
+    trainer.train()
+    trainer.model.save_pretrained(args.output)
+    tokenizer.save_pretrained(args.output)
+
+    try:
+        from llama_cpp import convert
+        gguf_path = os.path.join(args.output, "model.gguf")
+        convert(args.output, gguf_path)
+        print(f"Saved GGUF model to {gguf_path}")
+    except Exception as e:
+        print(f"Failed to convert to GGUF: {e}. Install llama_cpp to enable conversion.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple script to finetune Llama3 in 4-bit LoRA and export gguf
- document dataset formatting and training steps
- link to the new guide in the README

## Testing
- `python -m py_compile code/train_lora_gguf.py`
- `pip install -r requirements.txt` *(failed: operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6854d168e7488321a8cf2e1f5b2fbb4c